### PR TITLE
adding dockerfile and config file to deploy version of the jaeger col…

### DIFF
--- a/terraform/ecs_dockerfiles/jaeger_collector_private/Dockerfile
+++ b/terraform/ecs_dockerfiles/jaeger_collector_private/Dockerfile
@@ -1,0 +1,9 @@
+FROM jaegertracing/jaeger:2.11.0
+
+EXPOSE 4317
+EXPOSE 4318
+EXPOSE 13133
+
+COPY config.yml ./etc
+
+CMD ["--config", "./etc/config.yml"]

--- a/terraform/ecs_dockerfiles/jaeger_collector_private/config.yml
+++ b/terraform/ecs_dockerfiles/jaeger_collector_private/config.yml
@@ -1,0 +1,59 @@
+service:
+  extensions: [jaeger_storage, healthcheckv2] # removed jaeger_query, since it's going in its own container
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger_storage_exporter, spanmetrics]
+
+
+    metrics: 
+      receivers: [spanmetrics]
+      processors: [batch]
+      exporters: [prometheus]
+
+extensions:
+  healthcheckv2:
+    use_v2: true
+    http:
+
+  jaeger_storage:
+    backends:
+      opensearch_storage:
+        opensearch:
+          server_urls:
+            - http://opensearch-api.rvr-private:9200
+
+
+connectors: 
+  spanmetrics:  # spanmetrics will generate for every span that flows through a counter measure (how many spans) and a histogram metric (duration distribution) 
+    histogram:  
+      explicit: # explicitly setting bucket boundaries (another option is exponential) 
+        buckets: [100us, 1ms, 2ms, 6ms, 10ms, 100ms, 250ms] # way to calculate percentiles (p50, p95, p99, etc) (these values range from very fast to very slow in microservice latency) 
+    dimensions: # labels that will be attached to generated metrics. Connector will look at span attributes and extract them as metric labels. 
+      - name: http.method 
+        default: GET 
+      - name: http.status_code 
+      - name: service_name 
+    dimensions_cache_size: 1000 # caches unique dimension combinations  (this cache size is generally good for a medium deployment size ). Do not add high cardinality dimensions like users or the cache could explode lol 
+    aggregation_temporality: "CUMULATIVE" #determines how metrics are counted over time.  Cumulative means it will start at 0 and keep growing. It includes all values from the start 
+    metrics_flush_interval: 15s  # connector will export metrics this often 
+
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  jaeger_storage_exporter:
+    trace_storage: opensearch_storage
+
+  prometheus: 
+    endpoint: 0.0.0.0:8889


### PR DESCRIPTION
…lector intended to run on private network

Also exposes jaeger's health check port 13133