### PR TITLE
Added infra to set up the HotROD demo app in its own ECS cluster in t…

### DIFF
--- a/terraform/setup/_data.tf
+++ b/terraform/setup/_data.tf
@@ -1,0 +1,3 @@
+data "aws_iam_role" "ecs_task" {
+  name = "ecsTaskExecutionRole"
+}

--- a/terraform/setup/cluster.tf
+++ b/terraform/setup/cluster.tf
@@ -1,0 +1,9 @@
+resource "aws_ecs_cluster" "demo" {
+  name = "rvr-demo"
+}
+
+resource "aws_ecs_cluster_capacity_providers" "demo" {
+  cluster_name = aws_ecs_cluster.demo.name
+
+  capacity_providers = ["FARGATE"]
+}

--- a/terraform/setup/hotrod.tf
+++ b/terraform/setup/hotrod.tf
@@ -1,0 +1,106 @@
+resource "aws_security_group" "hotrod" {
+  name        = "hotrod"
+  description = "Allow all traffic needed for the hotrod demo app"
+  vpc_id      = aws_vpc.main.id
+
+  tags = {
+    Name = "hotrod"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "hotrod" {
+  security_group_id = aws_security_group.hotrod.id
+  cidr_ipv4 = "0.0.0.0/0"
+  from_port   = 8080
+  ip_protocol = "tcp"
+  to_port     = 8080
+}
+
+resource "aws_vpc_security_group_egress_rule" "hotrod" {
+  security_group_id = aws_security_group.hotrod.id
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 443
+  ip_protocol = "tcp"
+  to_port     = 443
+}
+
+resource "aws_ecs_task_definition" "hotrod" {
+  family                   = "rvr_hotrod"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 1024
+  memory                   = 2048
+  execution_role_arn       = data.aws_iam_role.ecs_task.arn
+
+  container_definitions = <<TASK_DEFINITION
+[
+  {
+    "cpu": 0,
+    "environment": [
+      {
+        "name": "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "value": "${var.HOTROD_ENDPOINT}"
+      }
+    ],
+    "environmentFiles": [],
+    "essential": true,
+    "image": "jaegertracing/example-hotrod:latest",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "/ecs/rvr-test-hotrod",
+        "awslogs-create-group": "true",
+        "awslogs-region": "${local.region}",
+        "awslogs-stream-prefix": "ecs"
+      },
+      "secretOptions": []
+    },
+    "mountPoints": [],
+    "name": "hotrod",
+    "portMappings": [
+      {
+        "appProtocol": "http",
+        "containerPort": 8080,
+        "hostPort": 8080,
+        "name": "ui",
+        "protocol": "tcp"
+      },
+      {
+        "appProtocol": "http",
+        "containerPort": 8083,
+        "hostPort": 8083,
+        "name": "other",
+        "protocol": "tcp"
+      }
+    ],
+    "systemControls": [],
+    "ulimits": [],
+    "volumesFrom": []
+  }
+]
+TASK_DEFINITION
+}
+
+resource "aws_ecs_service" "rvr_hotrod" {
+  name                          = "rvr_hotrod"
+  cluster                       = aws_ecs_cluster.demo.id
+  task_definition               = aws_ecs_task_definition.hotrod.arn
+  desired_count                 = 1
+  force_delete                  = true
+  availability_zone_rebalancing = "DISABLED"
+  launch_type                   = "FARGATE"
+  wait_for_steady_state         = true
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  network_configuration {
+    assign_public_ip = false
+    security_groups = [
+      aws_security_group.hotrod.id
+    ]
+    subnets = [aws_subnet.private-a.id]
+  }
+}

--- a/terraform/setup/main.tf
+++ b/terraform/setup/main.tf
@@ -8,6 +8,10 @@ terraform {
 }
 
 provider "aws" {
+  region = local.region
+}
+
+locals {
   region = "us-east-1"
 }
 
@@ -22,7 +26,7 @@ resource "aws_vpc" "main" {
 resource "aws_subnet" "public-a" {
   vpc_id            = aws_vpc.main.id
   cidr_block        = "10.0.1.0/24"
-  availability_zone = "us-east-1a"
+  availability_zone = "${local.region}a"
 
   tags = {
     Name = "rvr-public-a"
@@ -32,7 +36,7 @@ resource "aws_subnet" "public-a" {
 resource "aws_subnet" "public-b" {
   vpc_id            = aws_vpc.main.id
   cidr_block        = "10.0.2.0/24"
-  availability_zone = "us-east-1b"
+  availability_zone = "${local.region}b"
 
   tags = {
     Name = "rvr-public-b"
@@ -73,7 +77,7 @@ resource "aws_route_table_association" "public-assoc-b" {
 resource "aws_subnet" "private-a" {
   vpc_id            = aws_vpc.main.id
   cidr_block        = "10.0.3.0/24"
-  availability_zone = "us-east-1a"
+  availability_zone = "${local.region}a"
 
   tags = {
     Name = "rvr-private-a"

--- a/terraform/setup/variables.tf
+++ b/terraform/setup/variables.tf
@@ -1,0 +1,3 @@
+variable "HOTROD_ENDPOINT" {
+  type = string
+}


### PR DESCRIPTION
…he private subnet for testing/demo purposes.

The easiest way to make this publicly accessible (so we can use it to generate trace data) is to set up a separate ALB to point at it; this still needs to be done.