### PR TITLE
1) Added infrastructure code to spin up the MCP service

### DIFF
--- a/terraform/infrastructure/alb.tf
+++ b/terraform/infrastructure/alb.tf
@@ -1,6 +1,7 @@
 resource "aws_acm_certificate" "user-cert" {
-  private_key      = file(var.USER_CERTIFICATE_PRIVATE_KEY_FILE)
-  certificate_body = file(var.USER_CERTIFICATE_BODY_FILE)
+  private_key       = file(var.USER_CERTIFICATE_PRIVATE_KEY_FILE)
+  certificate_body  = file(var.USER_CERTIFICATE_BODY_FILE)
+  certificate_chain = file(var.USER_CERTIFICATE_CHAIN_FILE)
 }
 
 resource "aws_security_group" "alb-sg" {

--- a/terraform/infrastructure/mcp.tf
+++ b/terraform/infrastructure/mcp.tf
@@ -35,3 +35,133 @@ resource "aws_vpc_security_group_egress_rule" "mcp_to_prometheus" {
   ip_protocol                  = "tcp"
   to_port                      = 9090
 }
+
+# task definition
+resource "aws_ecs_task_definition" "mcp" {
+  family                   = "rvr_mcp"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = data.aws_iam_role.ecs_task.arn
+  container_definitions    = <<TASK_DEFINITION
+[
+ {
+    "cpu": 256,
+    "environment": [
+      {
+        "name": "URL",
+        "value": "http://query_ui.retriever:16686"
+      }
+    ],
+    "environmentFiles": [],
+    "essential": true,
+    "image": "runretriever/mcp-server:latest",
+    "mountPoints": [],
+    "name": "mcp",
+    "portMappings": [
+      {
+        "appProtocol": "http",
+        "containerPort": 3000,
+        "hostPort": 3000,
+        "name": "mcp",
+        "protocol": "tcp"
+      }
+    ],
+    "systemControls": [],
+    "ulimits": [],
+    "volumesFrom": []
+  }
+  ]
+TASK_DEFINITION
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+}
+
+# ALB target group
+resource "aws_lb_target_group" "mcp" {
+  name        = "mcp-tg"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = var.VPC_ID
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+    interval            = 30
+    path                = "/health"
+    port                = "3000"
+    protocol            = "HTTP"
+    matcher             = "200"
+  }
+
+  deregistration_delay = 30
+
+  tags = {
+    Name = "mcp-tg"
+  }
+}
+
+# ALB listener rule for HTTPS
+resource "aws_lb_listener_rule" "mcp" {
+  listener_arn = aws_lb_listener.dummy-https.arn
+  priority     = 101
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.mcp.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/mcp"]
+    }
+  }
+
+  tags = {
+    Name = "mcp-https-rule"
+  }
+}
+
+
+resource "aws_ecs_service" "mcp" {
+  name                          = "rvr_mcp"
+  cluster                       = aws_ecs_cluster.main.id
+  task_definition               = aws_ecs_task_definition.mcp.arn
+  desired_count                 = 1
+  force_delete                  = true
+  availability_zone_rebalancing = "DISABLED"
+  launch_type                   = "FARGATE"
+  wait_for_steady_state         = true
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  network_configuration {
+    assign_public_ip = false
+    security_groups = [
+      aws_security_group.tls_out.id,
+      aws_security_group.mcp.id
+    ]
+    subnets = [var.PRIVATE_SUBNET_ID]
+  }
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_http_namespace.main.arn
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.mcp.arn
+    container_name   = "mcp"
+    container_port   = 3000
+  }
+}

--- a/terraform/infrastructure/variables.tf
+++ b/terraform/infrastructure/variables.tf
@@ -21,3 +21,7 @@ variable "USER_CERTIFICATE_PRIVATE_KEY_FILE" {
 variable "USER_CERTIFICATE_BODY_FILE" {
   type = string
 }
+
+variable "USER_CERTIFICATE_CHAIN_FILE" {
+  type = string
+}


### PR DESCRIPTION
- Note that we will need to update the task definition with an environment variable for the Prometheus ECS Connect endpoint once we have Prometheus set up.

2) Updated the ACM certificate for the ALB to provide the full certificate chain. The Cursor MCP client was not happy with the old certificate; the new certificate is more robust and allows the MCP client to connect.