### PR TITLE
Update MCP Dockerfile and Terraform configuration

### DIFF
--- a/terraform/ecs_dockerfiles/mcp/Dockerfile
+++ b/terraform/ecs_dockerfiles/mcp/Dockerfile
@@ -1,18 +1,27 @@
-FROM node:lts-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 
-COPY package.json package-lock.json ./
+
+COPY mcp/package*.json ./
+
 
 RUN npm ci
 
-COPY tsconfig.json ./
-COPY src ./src
+COPY mcp/authentication/ ./authentication/
+
+
+COPY mcp/src/ ./src/
+COPY mcp/tsconfig.json ./
+
 
 RUN npm run build
 
+
 RUN npm prune --production
+
 
 EXPOSE 3000
 
-CMD ["npm", "start"]
+
+CMD ["node", "build/src/server.js"]

--- a/terraform/infrastructure/mcp.tf
+++ b/terraform/infrastructure/mcp.tf
@@ -54,9 +54,24 @@ resource "aws_ecs_task_definition" "mcp" {
         "value": "http://query_ui.retriever:16686"
       }
     ],
+    "secrets": [
+      {
+        "name": "JWT_SECRET",
+        "valueFrom": "${data.aws_secretsmanager_secret.jwt_secret.arn}"
+      }
+    ],
     "environmentFiles": [],
     "essential": true,
     "image": "runretriever/mcp-server:latest",
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "/ecs/rvr_mcp",
+        "awslogs-create-group": "true",
+        "awslogs-region": "${local.region}",
+        "awslogs-stream-prefix": "ecs"
+      }
+    },
     "mountPoints": [],
     "name": "mcp",
     "portMappings": [

--- a/terraform/infrastructure/secrets.tf
+++ b/terraform/infrastructure/secrets.tf
@@ -1,0 +1,22 @@
+# reference secret 
+data "aws_secretsmanager_secret" "jwt_secret" {
+    name = "retriever/jwt-secret"
+}
+
+# Grant ECS permission to read policy
+resource "aws_iam_role_policy" "ecs_secrets_access" {
+    role = data.aws_iam_role.ecs_task.name 
+
+    policy = jsonencode({
+        Version = "2012-10-17" 
+        Statement = [{
+            Effect = "Allow" 
+            Action = [
+                "secretsmanager:GetSecretValue"
+            ]
+            Resource = [
+                data.aws_secretsmanager_secret.jwt_secret.arn
+            ]
+        }]
+    })
+}


### PR DESCRIPTION
## JWT Authentication Implementation

### Docker Changes
- **File Structure**: Modified Dockerfile to copy `authentication/` and `src/` directories
- **Startup Command**: Changed CMD to execute from build output directory

### AWS Infrastructure
- **Task Definition**: Added `JWT_SECRET` injection via AWS Secrets Manager
- **Logging**: Configured CloudWatch logs for ECS task monitoring
- **IAM Policy**: Created `secrets.tf` to grant ECS execution role permission to read `JWT_SECRET`

### Security
- **Authentication**: All `/mcp` endpoints now require valid JWT token
- **Secret Management**: JWT secret stored securely in AWS Secrets Manager
- **Authorization**: Requests without valid token return 401 Unauthorized