### PR TITLE
Refactor ALB listener resources and update references

### DIFF
--- a/terraform/infrastructure/alb.tf
+++ b/terraform/infrastructure/alb.tf
@@ -105,35 +105,37 @@ resource "aws_lb" "public-endpoint" {
   }
 }
 
-resource "aws_lb_listener" "dummy-http" {
+# Rename from dummy-http to public-http
+moved {
+  from = aws_lb_listener.dummy-http
+  to   = aws_lb_listener.public-http
+}
+
+resource "aws_lb_listener" "public-http" {
   load_balancer_arn = aws_lb.public-endpoint.arn
   port              = "80"
   protocol          = "HTTP"
 
   default_action {
-    type = "fixed-response"
-
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "successfully connected to alb over http"
-      status_code  = "200"
-    }
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.query.arn
   }
 }
 
-resource "aws_lb_listener" "dummy-https" {
+# Rename from dummy-https to public-https
+moved {
+  from = aws_lb_listener.dummy-https
+  to   = aws_lb_listener.public-https
+}
+
+resource "aws_lb_listener" "public-https" {
   load_balancer_arn = aws_lb.public-endpoint.arn
   port              = "443"
   protocol          = "HTTPS"
   certificate_arn   = aws_acm_certificate.user-cert.arn
 
   default_action {
-    type = "fixed-response"
-
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "successfully connected to alb over https"
-      status_code  = "200"
-    }
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.query.arn
   }
 }

--- a/terraform/infrastructure/mcp.tf
+++ b/terraform/infrastructure/mcp.tf
@@ -125,7 +125,7 @@ resource "aws_lb_target_group" "mcp" {
 
 # ALB listener rule for HTTPS
 resource "aws_lb_listener_rule" "mcp" {
-  listener_arn = aws_lb_listener.dummy-https.arn
+  listener_arn = aws_lb_listener.public-https.arn
   priority     = 101
 
   action {

--- a/terraform/infrastructure/query.tf
+++ b/terraform/infrastructure/query.tf
@@ -147,47 +147,7 @@ resource "aws_lb_target_group" "query" {
   }
 }
 
-# ALB listener rule for HTTPS
-resource "aws_lb_listener_rule" "query" {
-  listener_arn = aws_lb_listener.dummy-https.arn
-  priority     = 100
 
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.query.arn
-  }
-
-  condition {
-    path_pattern {
-      values = ["/jaeger*"]
-    }
-  }
-
-  tags = {
-    Name = "query-https-rule"
-  }
-}
-
-# ALB listener rule for HTTP (for testing)
-resource "aws_lb_listener_rule" "query_http" {
-  listener_arn = aws_lb_listener.dummy-http.arn
-  priority     = 100
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.query.arn
-  }
-
-  condition {
-    path_pattern {
-      values = ["/jaeger*"]
-    }
-  }
-
-  tags = {
-    Name = "query-http-rule"
-  }
-}
 
 # ecs service
 resource "aws_ecs_service" "query" {
@@ -242,7 +202,7 @@ resource "aws_ecs_service" "query" {
   }
 
   depends_on = [
-    aws_lb_listener_rule.query,
+    aws_lb_listener.public-https,
     aws_ecs_service.rvr_opensearch
   ]
 }


### PR DESCRIPTION
 ## Set Jaeger UI as Default ALB Target

  ### Changes
  - **ALB Listeners**: Changed default action from fixed response to
  forward to Jaeger UI target group
  - **Routing**: Removed `/jaeger*` path-based listener rules (no
  longer needed)
  - **Naming**: Renamed `dummy-http/https` listeners to
  `public-http/https` for clarity

  ### Result
  - `https://rvr.philipkn.app/` → Jaeger UI (no `/jaeger` prefix
  required)
  - `https://rvr.philipkn.app/mcp` → MCP service (unchanged)
  - When you load the page it appends`/search` remove that to access other services
